### PR TITLE
Fix lazy.nvim plugin loading

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -8,5 +8,9 @@ vim.opt.rtp:prepend(lazypath)
 
 require("config.options")
 require("config.keymaps")
-require("lazy").setup("plugins")
+-- Load plugin specifications
+require("lazy").setup({
+  { import = "plugins" },
+  require("plugins"),
+})
 


### PR DESCRIPTION
## Summary
- load plugin specs from `lua/plugins` directory in Neovim config

## Testing
- `nvim --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68552a3cf92c832882a94afacd5747d3